### PR TITLE
Add VMware cluster reports

### DIFF
--- a/test-reports/hypervisor/vmware/ESXi_70U2/39f17ba7-b59e-4bdd-849e-e460078a0382/39f17ba7-b59e-4bdd-849e-e460078a0382.xsos.out
+++ b/test-reports/hypervisor/vmware/ESXi_70U2/39f17ba7-b59e-4bdd-849e-e460078a0382/39f17ba7-b59e-4bdd-849e-e460078a0382.xsos.out
@@ -1,0 +1,144 @@
+#######################################
+# VM configuration:
+# CPU
+# - single socket
+# - CPU hotplug and I/O MMU disabled
+# Memory
+# - Memory hotplug disabled
+# Storage
+# - VMware Paravirtual SCSI controller
+# Networking
+# - vmxnet3 adapter
+# Boot option
+# - BIOS
+#
+# Also tested with:
+# Storage
+# - LSI Logic SAS SCSI controller (adds Taint-check 27 BIT_BY_ZOMBIE)
+# - LSI Logic Parallel SCSI controller (adds Taint-check 27 BIT_BY_ZOMBIE)
+# - NVMe controller (empty Whole Disks from /proc/partitions)
+#######################################
+DMIDECODE
+  BIOS:
+    Vend: Phoenix Technologies LTD
+    Vers: 6.00
+    Date: 11/12/2020
+    BIOS Rev: 4.6
+    FW Rev:   0.0
+  System:
+    Mfr:  VMware, Inc.
+    Prod: VMware Virtual Platform
+    Vers: None
+    Ser:  ⣿⣿⣿⣿⣿⣿-⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿-⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿
+    UUID: ⣿⣿⣿⣿⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+  CPU:
+    2 of 2 CPU sockets populated, 2 cores/0 threads per CPU
+    4 total cores, 0 total threads
+    Mfr:  GenuineIntel
+    Fam:  Unknown
+    Freq: 2500 MHz
+    Vers: Intel(R) Core(TM) i5-6500T CPU @ 2.50GHz
+  Memory:
+    Total: 2048 MiB (2 GiB)
+    DIMMs: 1 of 192 populated
+    MaxCapacity: 2048 MiB (2 GiB / 0.00 TiB)
+
+OS
+  Hostname: SCRUBBED
+  Distro:   [redhat-release] Rocky Linux release 8.3
+            [rocky-release] Rocky Linux release 8.3
+            [os-release] Rocky Linux 8.3 8.3
+  RHN:      (missing)
+  RHSM:     hostname = SCRUBBED
+            proxy_hostname =
+  YUM:      4 enabled plugins: debuginfo-install, product-id, subscription-manager, tracer_upload
+  Runlevel: N 3  (default multi-user)
+  SELinux:  enforcing  (default enforcing)
+  Arch:     mach=x86_64  cpu=x86_64  platform=x86_64
+  Kernel:
+    Booted kernel:  4.18.0-240.22.1.el8.x86_64
+    GRUB default:     
+    Build version:
+      Linux version 4.18.0-240.22.1.el8.x86_64 (mockbuild@7dfc074d1e13452e94271ec95cb31ed9) (gcc version 8.3.1 20191121 (Red Hat 8.3.1-5) (GCC)) #1 SMP Mon Apr 12 04:29:16 UTC 2021
+    Booted kernel cmdline:
+      BOOT_IMAGE=(hd0,msdos1)/vmlinuz-4.18.0-240.22.1.el8.x86_64 root=UUID=7204f4ef-3cb6-41df-8531-7fc7d35f6a67 ro crashkernel=auto resume=UUID=c6536419-b664-46f5-92be-c5b2f994b191 rhgb quiet
+    GRUB default kernel cmdline:  
+      
+    Taint-check: 0  (kernel untainted)
+    - - - - - - - - - - - - - - - - - - -
+  Sys time:  Thu May 13 15:08:56 CEST 2021
+  Boot time: Thu May 13 14:48:39 CEST 2021  (epoch: 1620910119)
+  Time Zone: Europe/Vienna
+  Uptime:    20 min,  1 user
+  LoadAvg:   [2 CPU] 0.15 (8%), 0.03 (2%), 0.01 (0%)
+  /proc/stat:
+    procs_running: 1   procs_blocked: 0    processes [Since boot]: 1814
+    cpu [Utilization since boot]:
+      us 1%, ni 0%, sys 0%, idle 98%, iowait 0%, irq 0%, sftirq 0%, steal 0%
+
+CPU
+  2 logical processors (2 CPU cores)
+  1 Intel Core i5-6500T CPU @ 2.50GHz (flags: aes,constant_tsc,ht,lm,nx,pae,rdrand) 
+  └─2 threads / 2 cores each
+
+MEMORY
+  Stats graphed as percent of MemTotal:
+    MemUsed    ▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊.................................  34.8%
+    Buffers    ..................................................   0.2%
+    Cached     ▊▊▊▊▊▊▊▊▊.........................................  17.5%
+    HugePages  ..................................................   0.0%
+    Dirty      ..................................................   0.2%
+  RAM:
+    1.8 GiB total ram
+    0.6 GiB (35%) used
+    0.3 GiB (17%) used excluding Buffers/Cached
+    0 GiB (0%) dirty
+  HugePages:
+    No ram pre-allocated to HugePages
+  THP:
+    53248 kB allocated to THP 
+  LowMem/Slab/PageTables/Shmem:
+    0.1 GiB (6%) of total ram used for Slab
+    0.01 GiB (0%) of total ram used for PageTables
+    0.01 GiB (0%) of total ram used for Shmem
+  Swap:
+    0 GiB (0%) used of 1.6 GiB total
+
+STORAGE
+  Whole Disks from /proc/partitions:
+    1 disks, totaling 16 GiB (0.02 TiB)
+    - - - - - - - - - - - - - - - - - - - - -
+    Disk 	Size in GiB
+    ----	-----------
+    sda 	16
+
+  Disk layout from lsblk:
+    NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+    sda      8:0    0   16G  0 disk 
+    ├─sda1   8:1    0    1G  0 part /boot
+    ├─sda2   8:2    0  1.6G  0 part [SWAP]
+    └─sda3   8:3    0 13.4G  0 part /
+    sr0     11:0    1 1024M  0 rom  
+
+  Filesystem usage from df:
+    Filesystem     1K-blocks    Used Available Use% Mounted on
+    /dev/sda3       14039040 1790252  12248788  13% /
+    /dev/sda1        1038336  189340    848996  19% /boot
+
+DM-MULTIPATH
+  [No paths detected]
+
+LSPCI
+  Net:
+    (1) VMware VMXNET3 Ethernet Controller (rev 01)
+  Storage:
+    (1) VMware SATA AHCI controller
+    (1) VMware PVSCSI SCSI Controller (rev 02)
+  VGA:
+    VMware SVGA II Adapter
+
+ETHTOOL
+  Interface Status:
+    ens160  0000:03:00.0  link=up 10000Mb/s full (autoneg=N)  rx ring 1024/4096  drv vmxnet3 v1.5.0.0-k-NAPI / fw UNKNOWN
+  Interface Errors:
+    [None]

--- a/test-reports/hypervisor/vmware/ESXi_70U2/497022b3-ebad-4480-a519-b9da0a32b96d/497022b3-ebad-4480-a519-b9da0a32b96d.xsos.out
+++ b/test-reports/hypervisor/vmware/ESXi_70U2/497022b3-ebad-4480-a519-b9da0a32b96d/497022b3-ebad-4480-a519-b9da0a32b96d.xsos.out
@@ -1,0 +1,157 @@
+#######################################
+# VM configuration:
+# CPU
+# - single socket
+# - CPU hotplug and I/O MMU disabled
+# Memory
+# - Memory hotplug disabled
+# Storage
+# - VMware Paravirtual SCSI controller
+# Networking
+# - vmxnet3 adapter
+# Boot option
+# - EFI
+# - Secure Boot disabled
+#
+# Also tested with:
+# CPU
+# - dual/quad socket
+# - CPU hotplug and I/O MMU enabled
+# Memory
+# - Memory hotplug enabled
+# Storage
+# - LSI Logic SAS SCSI controller (adds Taint-check 27 BIT_BY_ZOMBIE)
+# - LSI Logic Parallel SCSI controller (adds Taint-check 27 BIT_BY_ZOMBIE)
+# - SATA controller
+# - NVMe controller (empty Whole Disks from /proc/partitions)
+# Networking
+# - E1000e (drv e1000e)
+# - PVRDMA (drv vmxnet3)
+#######################################
+DMIDECODE
+  BIOS:
+    Vend: VMware, Inc.
+    Vers: VMW71.00V.17369862.B64.2012240522
+    Date: 12/24/2020
+    BIOS Rev:
+    FW Rev:  
+  System:
+    Mfr:  VMware, Inc.
+    Prod: VMware7,1
+    Vers: None
+    Ser:  ⣿⣿⣿⣿⣿⣿-⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿-⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿
+    UUID: ⣿⣿⣿⣿⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+  CPU:
+    2 of 2 CPU sockets populated, 2 cores/0 threads per CPU
+    4 total cores, 0 total threads
+    Mfr:  GenuineIntel
+    Fam:  Unknown
+    Freq: 2380 MHz
+    Vers: Intel(R) Core(TM) i5-6500T CPU @ 2.50GHz
+  Memory:
+    Total: 2048 MiB (2 GiB)
+    DIMMs: 1 of 130 populated
+    MaxCapacity: 2048 MiB (2 GiB / 0.00 TiB)
+
+OS
+  Hostname: SCRUBBED
+  Distro:   [redhat-release] Rocky Linux release 8.3
+            [rocky-release] Rocky Linux release 8.3
+            [os-release] Rocky Linux 8.3 8.3
+  RHN:      (missing)
+  RHSM:     hostname = SCRUBBED
+            proxy_hostname =
+  YUM:      4 enabled plugins: debuginfo-install, product-id, subscription-manager, tracer_upload
+  Runlevel: N 3  (default multi-user)
+  SELinux:  enforcing  (default enforcing)
+  Arch:     mach=x86_64  cpu=x86_64  platform=x86_64
+  Kernel:
+    Booted kernel:  4.18.0-240.22.1.el8.x86_64
+    GRUB default:   unknown  (no grub config file)  
+    Build version:
+      Linux version 4.18.0-240.22.1.el8.x86_64 (mockbuild@7dfc074d1e13452e94271ec95cb31ed9) (gcc version 8.3.1 20191121 (Red Hat 8.3.1-5) (GCC)) #1 SMP Mon Apr 12 04:29:16 UTC 2021
+    Booted kernel cmdline:
+      BOOT_IMAGE=(hd0,gpt2)/vmlinuz-4.18.0-240.22.1.el8.x86_64 root=/dev/mapper/rl-root ro crashkernel=auto resume=/dev/mapper/rl-swap rd.lvm.lv=rl/root rd.lvm.lv=rl/swap rhgb quiet
+    GRUB default kernel cmdline:  
+      unknown  (no grub config file)
+    Taint-check: 0  (kernel untainted)
+    - - - - - - - - - - - - - - - - - - -
+  Sys time:  Thu May 13 15:07:03 CEST 2021
+  Boot time: Thu May 13 14:36:48 CEST 2021  (epoch: 1620909408)
+  Time Zone: Europe/Vienna
+  Uptime:    30 min,  1 user
+  LoadAvg:   [2 CPU] 0.00 (0%), 0.00 (0%), 0.00 (0%)
+  /proc/stat:
+    procs_running: 1   procs_blocked: 0    processes [Since boot]: 1986
+    cpu [Utilization since boot]:
+      us 1%, ni 0%, sys 0%, idle 99%, iowait 0%, irq 0%, sftirq 0%, steal 0%
+
+CPU
+  2 logical processors (2 CPU cores)
+  1 Intel Core i5-6500T CPU @ 2.50GHz (flags: aes,constant_tsc,ht,lm,nx,pae,rdrand) 
+  └─2 threads / 2 cores each
+
+MEMORY
+  Stats graphed as percent of MemTotal:
+    MemUsed    ▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊................................  35.8%
+    Buffers    ..................................................   0.3%
+    Cached     ▊▊▊▊▊▊▊▊▊.........................................  18.0%
+    HugePages  ..................................................   0.0%
+    Dirty      ..................................................   0.2%
+  RAM:
+    1.8 GiB total ram
+    0.6 GiB (36%) used
+    0.3 GiB (18%) used excluding Buffers/Cached
+    0 GiB (0%) dirty
+  HugePages:
+    No ram pre-allocated to HugePages
+  THP:
+    59392 kB allocated to THP 
+  LowMem/Slab/PageTables/Shmem:
+    0.11 GiB (6%) of total ram used for Slab
+    0.01 GiB (0%) of total ram used for PageTables
+    0.01 GiB (0%) of total ram used for Shmem
+  Swap:
+    0 GiB (0%) used of 1.6 GiB total
+
+STORAGE
+  Whole Disks from /proc/partitions:
+    1 disks, totaling 16 GiB (0.02 TiB)
+    - - - - - - - - - - - - - - - - - - - - -
+    Disk 	Size in GiB
+    ----	-----------
+    sda 	16
+
+  Disk layout from lsblk:
+    NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+    sda           8:0    0   16G  0 disk 
+    ├─sda1        8:1    0  600M  0 part /boot/efi
+    ├─sda2        8:2    0    1G  0 part /boot
+    └─sda3        8:3    0 14.4G  0 part 
+      ├─rl-root 253:0    0 12.8G  0 lvm  /
+      └─rl-swap 253:1    0  1.6G  0 lvm  [SWAP]
+    sr0          11:0    1 1024M  0 rom  
+
+  Filesystem usage from df:
+    Filesystem          1K-blocks    Used Available Use% Mounted on
+    /dev/mapper/rl-root  13420544 1792880  11627664  14% /
+    /dev/sda2             1038336  191396    846940  19% /boot
+    /dev/sda1              613184    7036    606148   2% /boot/efi
+
+DM-MULTIPATH
+  [No paths detected]
+
+LSPCI
+  Net:
+    (1) VMware VMXNET3 Ethernet Controller (rev 01)
+  Storage:
+    (1) VMware SATA AHCI controller
+    (1) VMware PVSCSI SCSI Controller (rev 02)
+  VGA:
+    VMware SVGA II Adapter
+
+ETHTOOL
+  Interface Status:
+    ens192  0000:0b:00.0  link=up 10000Mb/s full (autoneg=N)  rx ring 1024/4096  drv vmxnet3 v1.5.0.0-k-NAPI / fw UNKNOWN
+  Interface Errors:
+    [None]


### PR DESCRIPTION
These tests are from a VMware ESXi 7.0U2a cluster

And as I talked with stack, I added a comment header in which the other tested variations are noted, to not clutter the reports too much (only one with EFI and BIOS uploaded)