### PR TITLE
Added test report for Raspberry Pi 3b+

### DIFF
--- a/test-reports/hardware/raspberry-pi/rpi 3b+/7b5ccd10-2bcb-4166-bba9-336858be12e6.xsos.out
+++ b/test-reports/hardware/raspberry-pi/rpi 3b+/7b5ccd10-2bcb-4166-bba9-336858be12e6.xsos.out
@@ -1,0 +1,108 @@
+OS
+  Hostname: SCRUBBED
+  Distro:   [redhat-release] Rocky Linux release 8.4 (Green Obsidian)
+            [rocky-release] Rocky Linux release 8.4 (Green Obsidian)
+            [os-release] Rocky Linux 8.4 (Green Obsidian) 8.4 (Green Obsidian)
+  RHN:      (missing)
+  RHSM:     (missing)
+  YUM:      1 enabled plugins: debuginfo-install
+  Runlevel: N 5  (default )
+  SELinux:  enforcing  (default enforcing)
+  Arch:     mach=aarch64  cpu=aarch64  platform=aarch64
+  Kernel:
+    Booted kernel:  5.10.39-v8.1.el8
+    GRUB default:
+    Build version:
+      Linux version 5.10.39-v8.1.el8 (mockbuild@RpiRockyDev) (gcc (GCC) 8.4.1 20200928 (Red Hat 8.4.1-1), GNU ld version 2.30-93.el8) #1 SMP PREEMPT Sun Jun 13 21:06:16 UTC 2021
+    Booted kernel cmdline:
+      coherent_pool=1M 8250.nr_uarts=0 snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1 bcm2708_fb.fbwidth=1824 bcm2708_fb.fbheight=984 bcm2708_fb.fbswap=1 vc_mem.mem_base=0x3ec00000 vc_mem.mem_size=0x40000000
+      console=ttyAMA0,115200 console=tty1 root=PARTUUID=48E6D4F9-03   rootfstype=ext4 elevator=deadline rootwait
+    GRUB default kernel cmdline:
+
+    Taint-check: 1024  (see https://access.redhat.com/solutions/40594)
+      10  CRAP: Modules from drivers/staging are loaded
+    - - - - - - - - - - - - - - - - - - -
+  Sys time:  Tue Jun 29 14:38:09 UTC 2021
+  Boot time: Tue Jun 29 14:27:48 UTC 2021  (epoch: 1624976868)
+  Time Zone: UTC
+  Uptime:    10 min,  1 user
+  LoadAvg:   [4 CPU] 0.09 (2%), 0.16 (4%), 0.14 (4%)
+  /proc/stat:
+    procs_running: 2   procs_blocked: 0    processes [Since boot]: 1046
+    cpu [Utilization since boot]:
+      us 3%, ni 0%, sys 2%, idle 95%, iowait 1%, irq 0%, sftirq 0%, steal 0%
+
+CPU
+  4 logical processors
+
+
+MEMORY
+  Stats graphed as percent of MemTotal:
+    MemUsed    ▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊............................  44.6%
+    Buffers    ▊.................................................   1.3%
+    Cached     ▊▊▊▊▊▊▊▊▊▊▊▊▊.....................................  26.1%
+    HugePages  ..................................................   0.0%
+    Dirty      ..................................................   0.0%
+  RAM:
+    0.9 GiB total ram
+    0.4 GiB (45%) used
+    0.2 GiB (17%) used excluding Buffers/Cached
+    0 GiB (0%) dirty
+  HugePages:
+    No ram pre-allocated to HugePages
+  THP:
+    THP not currently in use
+  LowMem/Slab/PageTables/Shmem:
+    0.06 GiB (6%) of total ram used for Slab
+    0 GiB (0%) of total ram used for PageTables
+    0.02 GiB (2%) of total ram used for Shmem
+  Swap:
+    0 GiB (0%) used of 0.5 GiB total
+
+STORAGE
+  Whole Disks from /proc/partitions:
+    17 disks, totaling 30 GiB (0.03 TiB)
+    - - - - - - - - - - - - - - - - - - - - -
+    Disk        Size in GiB
+    ----        -----------
+    mmcblk0     30
+    ram0        0
+    ram1        0
+    ram10       0
+    ram11       0
+    ram12       0
+    ram13       0
+    ram14       0
+    ram15       0
+    ram2        0
+    ram3        0
+    ram4        0
+    ram5        0
+    ram6        0
+    ram7        0
+    ram8        0
+    ram9        0
+
+  Disk layout from lsblk:
+    NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+    mmcblk0     179:0    0 29.7G  0 disk
+    ├─mmcblk0p1 179:1    0  286M  0 part /boot
+    ├─mmcblk0p2 179:2    0  488M  0 part [SWAP]
+    └─mmcblk0p3 179:3    0  2.6G  0 part /
+
+  Filesystem usage from df:
+    Filesystem     1K-blocks    Used Available Use% Mounted on
+    /dev/root        2626068 1730080    852260  67% /
+    /dev/mmcblk0p1    292696   65680    227016  23% /boot
+
+LSPCI
+  Net:
+  Storage:
+  VGA:
+
+ETHTOOL
+  Interface Status:
+    eth0   usb-3f980000.usb-1.1.1  link=DOWN     rx ring UNKNOWN  drv lan78xx v5.10.39-v8.1.el8 / fw UNKNOWN
+    wlan0  mmc1:0001:1             link=UNKNOWN  rx ring UNKNOWN  drv brcmfmac v7.45.221 / fw 01-bbd9282b
+  Interface Errors:
+    [None]


### PR DESCRIPTION
Xsos hardware report for a raspberry pi 3b+

Tested on Rocky Linux 8.4 arm64 iso