### PR TITLE
Add an example running OpenQA in containers

### DIFF
--- a/openqa-docker/README.md
+++ b/openqa-docker/README.md
@@ -1,0 +1,32 @@
+# Running OpenQA from Docker
+
+This document provides a reference example showing how OpenQA can be set up to test Rocky Linux in a containerized environment.
+
+## Docker setup:
+
+Run these steps for systems using Fedora:
+ 
+1. Install packages: perl-Digest-SHA git docker
+1. Enable Docker service: `sudo systemctl enable --now docker`
+1. (Optional) Allow Docker use without sudo: `sudo usermod -aG docker $USER`
+
+## Podman setup:
+
+Run these steps for RHEL-based systems, such as Rocky Linux:
+
+1. Install packages: perl-Digest-SHA git podman-docker
+1. Install dnsname Podman plugin:
+       https://github.com/containers/dnsname/blob/main/README_PODMAN.md#build-and-install
+
+## How to use
+
+- Build and start OpenQA container images by running `start.sh`
+- Stop OpenQA containers with `stop.sh`
+
+## Notes
+
+- OpenQA configuration is stored in the "data" folder
+- Webapp data is stored in the "data-postgres" folder. Delete this folder if you want to start fresh
+- Webserver connection is available at http://localhost:80 by default
+- VNC connection is available on port 5991 by default
+

--- a/openqa-docker/start.sh
+++ b/openqa-docker/start.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -eu
+
+arch="${1:-"$(uname -m)"}"
+postgres_dir="$(pwd)/data-postgres"
+openqa_dir="$(pwd)/data"
+openqa_web_port=80
+openqa_vnc_port=5991
+
+mkdir -p "$openqa_dir"/factory/{iso,hdd,other,tmp} "$openqa_dir"/{testresults,tests,conf} "$postgres_dir"
+
+cat << EOF > "$openqa_dir"/conf/client.conf
+[openqa_webui]
+key = 1234567890ABCDEF
+secret = 1234567890ABCDEF
+
+[localhost]
+key = 1234567890ABCDEF
+secret = 1234567890ABCDEF
+
+EOF
+
+cat << EOF > "$openqa_dir"/conf/openqa.ini
+[global]
+branding=plain
+download_domains = rockylinux.org fedoraproject.org opensuse.org
+
+[auth]
+method = Fake
+
+EOF
+
+cat << EOF > "$openqa_dir"/conf/database.ini
+
+[production]
+dsn = DBI:Pg:dbname=openqa;host=db;user=openqa;password=openqa
+
+[development]
+dsn = DBI:Pg:dbname=openqa;host=db;user=openqa;password=openqa
+
+EOF
+
+cat << EOF > "$openqa_dir"/conf/workers.ini
+[global]
+BACKEND = qemu
+HOST = http://openqa_webui
+
+EOF
+
+if [[ ! -d "$openqa_dir"/tests/rocky ]]; then
+    git clone https://github.com/rocky-linux/os-autoinst-distri-rocky.git "$openqa_dir"/tests/rocky
+    # Workaround - Replace the 'text' parameter of python subprocess.run with 'universal_newlines'.
+    #              These parameters mean the same thing, but 'text' is only available after 
+    #              python 3.7 which is too new for the OpenSUSE container image.
+    sed s/text=True/universal_newlines=True/ -i.orig "$openqa_dir"/tests/rocky/fifloader.py
+fi
+
+mkdir -p "$openqa_dir"/factory/iso/fixed
+if [[ ! -f "$openqa_dir"/factory/iso/fixed/CHECKSUM.valid ]]; then
+    (
+    cd "$openqa_dir"/factory/iso/fixed
+    curl -C - -O download.rockylinux.org/pub/rocky/8/isos/"$arch"/Rocky-8.4-"$arch"-boot.iso
+    curl -C - -O download.rockylinux.org/pub/rocky/8/isos/"$arch"/Rocky-8.4-"$arch"-minimal.iso
+    curl -C - -O download.rockylinux.org/pub/rocky/8/isos/"$arch"/Rocky-8.4-"$arch"-dvd1.iso
+    curl -C - -O download.rockylinux.org/pub/rocky/8/isos/"$arch"/CHECKSUM
+    chmod -R 777 "$openqa_dir"
+    shasum -a 256 --ignore-missing -c CHECKSUM
+    mv CHECKSUM CHECKSUM.valid
+    )
+fi
+
+if [[ ! -d openQA ]]; then
+    git clone https://github.com/os-autoinst/openQA
+    # Pin to fedora version for consistency - https://src.fedoraproject.org/rpms/openqa
+    git -C openQA checkout 6541adf5ec360cc3a5ad6966d373f1a3b6cc26aa
+fi
+
+docker build openQA/container/webui -t openqa_webui
+docker build openQA/container/worker -t openqa_worker
+docker pull postgres
+docker network create openQA || true
+
+docker build webui_rocky -t openqa_webui_rocky
+docker build worker_rocky -t openqa_worker_rocky
+
+echo "Starting postgres"
+docker run -d --network openQA -v "$postgres_dir":/var/lib/postgresql/data:z -e POSTGRES_PASSWORD=openqa -e POSTGRES_USER=openqa -e POSTGRES_DB=openqa --network-alias=db --name openqa_db postgres
+until docker exec openqa_db pg_isready -h db
+do sleep 1; done
+
+echo "Strating webui"
+docker run -d --network openQA -v "$openqa_dir":/data:z -p "$openqa_web_port":80 --network-alias=openqa_webui --name openqa_webui --privileged openqa_webui_rocky
+until docker exec openqa_webui curl --fail -s "http://localhost/login" > /dev/null
+do echo "waiting for webui"; sleep 1; done
+docker exec openqa_webui curl "http://localhost/login" # Fake login to set things up
+echo "webui ready"
+
+echo "Starting workers"
+docker run -d --network openQA -v "$openqa_dir":/data:z -p "$openqa_vnc_port":5991 --network-alias=openqa_worker_1 --name openqa_worker_1 --hostname openqa_worker_1 --privileged openqa_worker_rocky
+
+echo "Updating job templates"
+docker exec -w /var/lib/openqa/tests/rocky openqa_webui ./fifloader.py -l -c templates.fif.json templates-updates.fif.json
+
+echo "Posting job"
+docker exec openqa_webui openqa-cli api -X POST isos \
+    ISO=Rocky-8.4-"$arch"-minimal.iso \
+    ARCH="$arch" \
+    DISTRI=rocky \
+    FLAVOR=minimal-iso \
+    VERSION=8 \
+    BUILD="-$(date '+%Y-%m-%d.%H:%M:%S')"
+

--- a/openqa-docker/stop.sh
+++ b/openqa-docker/stop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu
+
+docker kill openqa_db || true
+docker kill openqa_webui || true
+docker kill openqa_worker_1 || true
+docker rm openqa_db || true
+docker rm openqa_webui || true
+docker rm openqa_worker_1 || true
+

--- a/openqa-docker/webui_rocky/Dockerfile
+++ b/openqa-docker/webui_rocky/Dockerfile
@@ -1,0 +1,5 @@
+FROM openqa_webui
+
+RUN zypper -n install python3 python3-jsonschema
+# SSL not needed so disable it
+RUN a2disflag SSL

--- a/openqa-docker/worker_rocky/Dockerfile
+++ b/openqa-docker/worker_rocky/Dockerfile
@@ -1,0 +1,17 @@
+FROM fedora:34 as edk2_images
+
+RUN dnf install -y edk2-aarch64
+
+FROM openqa_worker
+
+COPY --from=edk2_images /usr/share/edk2/aarch64/QEMU_EFI-pflash.raw /usr/share/edk2/aarch64/QEMU_EFI-pflash.raw
+COPY --from=edk2_images /usr/share/edk2/aarch64/vars-template-pflash.raw /usr/share/edk2/aarch64/vars-template-pflash.raw
+
+# Fix for leap:15.3
+# - Installed qemu-hw-display-virtio-vga and qemu-hw-display-virtio-gpu to fix 'Virtio VGA not available'
+# - Installed qemu-hw-display-virtio-gpu-pci to fix 'virtio-gpu-pci' is not a valid device model name
+RUN zypper -n install qemu-hw-display-virtio-vga qemu-hw-display-virtio-gpu qemu-hw-display-virtio-gpu-pci  || true # Not needed or available for leap:15.2 or ealier
+
+# Install packages needed to test os-autoinst-distri-rocky
+RUN zypper -n install make cpanm perl-JSON
+RUN cpanm install REST::Client


### PR DESCRIPTION
Add a readme file, along scripts and dockerfiles which can be used to run OpenQA in a containerized environment using podman or docker. This is meant as a reference example only and should not be deployed to a production environment in its current form.

---
## Author checklist (to be completed by original Author)

- [x] I have signed the Rocky Open Source Contributor Agreement (ROSCA).
- [x] I certify this contribution complies with all conditions of the
  [Testing repository contributions guide](./CONTRIBUTING.md)
- [x] If applicable, steps and instructions have been tested to work on a real
  system.
- [ ] I have installed pre-commit and all commits in this PR pass.
- [ ] If applicable, I have GPG signed all commits and unploaded my private key
  to Github.

---
## Rocky Testing checklist  (to be completed by Rocky team)

- [ ] 1st Pass (Check that contribution is good fit for project and the Testing
  repository is the appropriate location)
- [ ] 2nd Pass (Confirm all pre-commit tests pass)
- [ ] 3nd Pass (Technical Review - check for technical correctness)
