### PR TITLE
Add Rocky Linux 9 RC1 test reports

### DIFF
--- a/test-reports/hypervisor/hyper-v/v2/4.0/rl9/636c4a1b-f380-4a50-b156-fc3e866d415e.xsos.out
+++ b/test-reports/hypervisor/hyper-v/v2/4.0/rl9/636c4a1b-f380-4a50-b156-fc3e866d415e.xsos.out
@@ -1,0 +1,126 @@
+DMIDECODE
+  BIOS:
+    Vend: Microsoft Corporation
+    Vers: Hyper-V UEFI Release v4.0
+    Date: 11/01/2019
+    BIOS Rev: 4.0
+    FW Rev:  
+  System:
+    Mfr:  Microsoft Corporation
+    Prod: Virtual Machine
+    Vers: Hyper-V UEFI Release v4.0
+    Ser:  ⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿
+    UUID: ⣿⣿⣿⣿⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+  CPU:
+    1 of 1 CPU sockets populated, 2 cores/2 threads per CPU
+    2 total cores, 2 total threads
+    Mfr:  Intel(R) Corporation
+    Fam:  Core i7
+    Freq: 2600 MHz
+    Vers: Intel(R) Core(TM) i7-9850H CPU @ 2.60GHz
+  Memory:
+    Total: 2048 MiB (2 GiB)
+    DIMMs: 1 of 6 populated
+    MaxCapacity: 0 MiB (0 GiB / 0.00 TiB)
+
+OS
+  Hostname: SCRUBBED
+  Distro:   [redhat-release] Rocky Linux release 9.0 (Blue Onyx)
+            [rocky-release] Rocky Linux release 9.0 (Blue Onyx)
+            [os-release] Rocky Linux 9.0 (Blue Onyx) 9.0 (Blue Onyx)
+  RHN:      (missing)
+  RHSM:     (missing)
+  YUM:      1 enabled plugins: debuginfo-install
+  Runlevel: N 3  (default multi-user)
+  SELinux:  enforcing  (default enforcing)
+  Arch:     mach=x86_64  cpu=x86_64  platform=x86_64
+  Kernel:
+    Booted kernel:  5.14.0-70.13.1.el9_0.x86_64
+    GRUB default:     
+    Build version:
+      Linux version 5.14.0-70.13.1.el9_0.x86_64 (mockbuild@dal1-prod-builder001.bld.equ.rockylinux.org) (gcc (GCC) 
+      11.2.1 20220127 (Red Hat 11.2.1-9), GNU ld version 2.35.2-17.el9) #1 SMP PREEMPT Wed May 25 21:01:57 UTC 2022
+    Booted kernel cmdline:
+      BOOT_IMAGE=(hd0,gpt2)/vmlinuz-5.14.0-70.13.1.el9_0.x86_64 root=/dev/mapper/rl_rocky9-root ro 
+      crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M resume=/dev/mapper/rl_rocky9-swap rd.lvm.lv=rl_rocky9/root 
+      rd.lvm.lv=rl_rocky9/swap
+    GRUB default kernel cmdline:  
+      
+    Taint-check: 0  (kernel untainted)
+    - - - - - - - - - - - - - - - - - - -
+  Sys time:  Fri Jun 24 07:49:54 PM CEST 2022
+  Boot time: Fri Jun 24 07:37:13 PM CEST 2022
+  Time Zone: Europe/Belgrade
+  Uptime:    12 min,  2 users
+  LoadAvg:   [2 CPU] 0.12 (6%), 0.05 (2%), 0.01 (0%)
+  /proc/stat:
+    procs_running: 1   procs_blocked: 0    processes [Since boot]: 14633
+    cpu [Utilization since boot]:
+      us 1%, ni 0%, sys 1%, idle 98%, iowait 0%, irq 0%, sftirq 0%, steal 0%
+
+CPU
+  2 logical processors (1 CPU cores)
+  1 Intel Core i7-9850H CPU @ 2.60GHz (flags: aes,constant_tsc,ht,lm,nx,pae,rdrand) 
+  └─2 threads / 1 cores each
+
+MEMORY
+  Stats graphed as percent of MemTotal:
+    MemUsed    ▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊.........  82.0%
+    Buffers    ..................................................   0.6%
+    Cached     ▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊................................  36.4%
+    HugePages  ..................................................   0.0%
+    Dirty      ..................................................   0.0%
+  RAM:
+    0.5 GiB total ram
+    0.4 GiB (82%) used
+    0.2 GiB (45%) used excluding Buffers/Cached
+    0 GiB (0%) dirty
+  HugePages:
+    No ram pre-allocated to HugePages
+  THP:
+    0.02 GiB allocated to THP 
+  LowMem/Slab/PageTables/Shmem:
+    0.06 GiB (12%) of total ram used for Slab
+    0 GiB (0%) of total ram used for PageTables
+    0.01 GiB (1%) of total ram used for Shmem
+  Swap:
+    0 GiB (0%) used of 0.8 GiB total
+
+STORAGE
+  Whole Disks from /proc/partitions:
+    1 disks, totaling 8 GiB (0.01 TiB)
+    - - - - - - - - - - - - - - - - - - - - -
+    Disk 	Size in GiB
+    ----	-----------
+    sda 	8
+
+  Disk layout from lsblk:
+    NAME               MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
+    sda                  8:0    0    8G  0 disk 
+    ├─sda1               8:1    0  600M  0 part /boot/efi
+    ├─sda2               8:2    0    1G  0 part /boot
+    └─sda3               8:3    0  6.4G  0 part 
+      ├─rl_rocky9-root 253:0    0  5.6G  0 lvm  /
+      └─rl_rocky9-swap 253:1    0  820M  0 lvm  [SWAP]
+    sr0                 11:0    1 1024M  0 rom  
+
+  Filesystem usage from df:
+    Filesystem                 1K-blocks    Used Available Use% Mounted on
+    /dev/mapper/rl_rocky9-root   5871616 1061684   4809932  19% /
+    /dev/sda2                    1038336  194020    844316  19% /boot
+    /dev/sda1                     613160    7136    606024   2% /boot/efi
+
+DM-MULTIPATH
+  [No paths detected]
+
+LSPCI
+  Net:
+  Storage:
+  VGA:
+
+ETHTOOL
+  Interface Status:
+    eth0    link=up 10000Mb/s full (autoneg=N)  rx ring 9709/18811  drv hv_netvsc v5.14.0-70.13.1.el9_0.x86_64 / fw N/A
+  Interface Errors:
+    [None]
+

--- a/test-reports/hypervisor/virtualbox/windows/rl9/a6ef6e6b-f7a6-47dd-ab0d-2e8767d24274.xsos.out
+++ b/test-reports/hypervisor/virtualbox/windows/rl9/a6ef6e6b-f7a6-47dd-ab0d-2e8767d24274.xsos.out
@@ -1,0 +1,128 @@
+DMIDECODE
+  BIOS:
+    Vend: innotek GmbH
+    Vers: VirtualBox
+    Date: 12/01/2006
+    BIOS Rev:
+    FW Rev:  
+  System:
+    Mfr:  innotek GmbH
+    Prod: VirtualBox
+    Vers: 1.2
+    Ser:  ⣿
+    UUID: ⣿⣿⣿⣿⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+  CPU:
+    0 of 0 CPU sockets populated, 0 cores/0 threads per CPU
+    0 total cores, 0 total threads
+    Mfr: 
+    Fam: 
+    Freq:
+    Vers:
+  Memory:
+    Total: 0 MiB (0 GiB)
+    DIMMs: 0 of 0 populated
+    MaxCapacity: 0 MiB (0 GiB / 0.00 TiB)
+
+OS
+  Hostname: SCRUBBED
+  Distro:   [redhat-release] Rocky Linux release 9.0 (Blue Onyx)
+            [rocky-release] Rocky Linux release 9.0 (Blue Onyx)
+            [os-release] Rocky Linux 9.0 (Blue Onyx) 9.0 (Blue Onyx)
+  RHN:      (missing)
+  RHSM:     (missing)
+  YUM:      1 enabled plugins: debuginfo-install
+  Runlevel: N 3  (default multi-user)
+  SELinux:  enforcing  (default enforcing)
+  Arch:     mach=x86_64  cpu=x86_64  platform=x86_64
+  Kernel:
+    Booted kernel:  5.14.0-70.13.1.el9_0.x86_64
+    GRUB default:     
+    Build version:
+      Linux version 5.14.0-70.13.1.el9_0.x86_64 (mockbuild@dal1-prod-builder001.bld.equ.rockylinux.org) (gcc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9), GNU ld 
+      version 2.35.2-17.el9) #1 SMP PREEMPT Wed May 25 21:01:57 UTC 2022
+    Booted kernel cmdline:
+      BOOT_IMAGE=(hd0,gpt2)/vmlinuz-5.14.0-70.13.1.el9_0.x86_64 root=/dev/mapper/rl_rocky9-root ro crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M 
+      resume=/dev/mapper/rl_rocky9-swap rd.lvm.lv=rl_rocky9/root rd.lvm.lv=rl_rocky9/swap
+    GRUB default kernel cmdline:  
+      
+    Taint-check: 0  (kernel untainted)
+    - - - - - - - - - - - - - - - - - - -
+  Sys time:  Mon Jun 20 11:26:46 AM CEST 2022
+  Boot time: Mon Jun 20 10:15:01 AM CEST 2022
+  Time Zone: Europe/Belgrade
+  Uptime:    1:11,  1 user
+  LoadAvg:   [2 CPU] 0.00 (0%), 0.02 (1%), 0.00 (0%)
+  /proc/stat:
+    procs_running: 1   procs_blocked: 0    processes [Since boot]: 11582
+    cpu [Utilization since boot]:
+      us 0%, ni 0%, sys 0%, idle 99%, iowait 0%, irq 0%, sftirq 0%, steal 0%
+
+CPU
+  2 logical processors (2 CPU cores)
+  1 Intel Pentium CPU G4560 @ 3.50GHz (flags: aes,constant_tsc,ht,lm,nx,pae,rdrand) 
+  └─2 threads / 2 cores each
+
+MEMORY
+  Stats graphed as percent of MemTotal:
+    MemUsed    ▊▊▊▊▊▊▊▊▊▊▊▊▊▊....................................  28.4%
+    Buffers    ..................................................   0.3%
+    Cached     ▊▊▊▊▊▊▊...........................................  14.4%
+    HugePages  ..................................................   0.0%
+    Dirty      ..................................................   0.0%
+  RAM:
+    1.7 GiB total ram
+    0.5 GiB (28%) used
+    0.2 GiB (14%) used excluding Buffers/Cached
+    0 GiB (0%) dirty
+  HugePages:
+    No ram pre-allocated to HugePages
+  THP:
+    0.01 GiB allocated to THP 
+  LowMem/Slab/PageTables/Shmem:
+    0.06 GiB (4%) of total ram used for Slab
+    0 GiB (0%) of total ram used for PageTables
+    0 GiB (0%) of total ram used for Shmem
+  Swap:
+    0 GiB (0%) used of 0.8 GiB total
+
+STORAGE
+  Whole Disks from /proc/partitions:
+    1 disks, totaling 8 GiB (0.01 TiB)
+    - - - - - - - - - - - - - - - - - - - - -
+    Disk 	Size in GiB
+    ----	-----------
+    sda 	8
+
+  Disk layout from lsblk:
+    NAME               MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
+    sda                  8:0    0    8G  0 disk 
+    ├─sda1               8:1    0  600M  0 part /boot/efi
+    ├─sda2               8:2    0    1G  0 part /boot
+    └─sda3               8:3    0  6.4G  0 part 
+      ├─rl_rocky9-root 253:0    0  5.6G  0 lvm  /
+      └─rl_rocky9-swap 253:1    0  820M  0 lvm  [SWAP]
+    sr0                 11:0    1 1024M  0 rom  
+
+  Filesystem usage from df:
+    Filesystem                 1K-blocks    Used Available Use% Mounted on
+    /dev/mapper/rl_rocky9-root   5871616 1025108   4846508  18% /
+    /dev/sda2                    1038336  194368    843968  19% /boot
+    /dev/sda1                     613184    7136    606048   2% /boot/efi
+
+DM-MULTIPATH
+  [No paths detected]
+
+LSPCI
+  Net:
+    (1) Red Hat, Inc. Virtio network device
+  Storage:
+    (1) Red Hat, Inc. Virtio SCSI (rev 01)
+  VGA:
+    VMware SVGA II Adapter
+
+ETHTOOL
+  Interface Status:
+    enp0s3  0000:00:03.0  link=up Unknown! unknown! (autoneg=N)  rx ring 256/256  drv virtio_net v1.0.0 / fw UNKNOWN
+  Interface Errors:
+    [None]
+

--- a/test-reports/hypervisor/vmware/Workstation/15.5/rl9/01b59fcc-cf58-4433-b5bd-bc29b7d302cc.xsos.out
+++ b/test-reports/hypervisor/vmware/Workstation/15.5/rl9/01b59fcc-cf58-4433-b5bd-bc29b7d302cc.xsos.out
@@ -1,0 +1,126 @@
+DMIDECODE
+  BIOS:
+    Vend: VMware, Inc.
+    Vers: VMW71.00V.16221537.B64.2005150253
+    Date: 05/15/2020
+    BIOS Rev:
+    FW Rev:  
+  System:
+    Mfr:  VMware, Inc.
+    Prod: VMware7,1
+    Vers: None
+    Ser:  ⣿⣿⣿⣿⣿⣿-⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿-⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿ ⣿⣿
+    UUID: ⣿⣿⣿⣿⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿-⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+  CPU:
+    2 of 128 CPU sockets populated, 1 cores/0 threads per CPU
+    2 total cores, 0 total threads
+    Mfr:  Not Specified
+    Fam:  Unknown
+    Freq: 3341 MHz
+    Vers: Unknown Processor
+  Memory:
+    Total: 2048 MiB (2 GiB)
+    DIMMs: 1 of 130 populated
+    MaxCapacity: 3072 MiB (3 GiB / 0.00 TiB)
+
+OS
+  Hostname: SCRUBBED
+  Distro:   [redhat-release] Rocky Linux release 9.0 (Blue Onyx)
+            [rocky-release] Rocky Linux release 9.0 (Blue Onyx)
+            [os-release] Rocky Linux 9.0 (Blue Onyx) 9.0 (Blue Onyx)
+  RHN:      (missing)
+  RHSM:     (missing)
+  YUM:      1 enabled plugins: debuginfo-install
+  Runlevel: N 3  (default multi-user)
+  SELinux:  enforcing  (default enforcing)
+  Arch:     mach=x86_64  cpu=x86_64  platform=x86_64
+  Kernel:
+    Booted kernel:  5.14.0-70.13.1.el9_0.x86_64
+    GRUB default:     
+    Build version:
+      Linux version 5.14.0-70.13.1.el9_0.x86_64 (mockbuild@dal1-prod-builder001.bld.equ.rockylinux.org) (gcc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9), GNU ld 
+      version 2.35.2-17.el9) #1 SMP PREEMPT Wed May 25 21:01:57 UTC 2022
+    Booted kernel cmdline:
+      BOOT_IMAGE=(hd0,gpt2)/vmlinuz-5.14.0-70.13.1.el9_0.x86_64 root=/dev/mapper/rl_rocky9-root ro crashkernel=1G-4G:192M,4G-64G:256M,64G-:512M 
+      resume=/dev/mapper/rl_rocky9-swap rd.lvm.lv=rl_rocky9/root rd.lvm.lv=rl_rocky9/swap
+    GRUB default kernel cmdline:  
+      
+    Taint-check: 0  (kernel untainted)
+    - - - - - - - - - - - - - - - - - - -
+  Sys time:  Mon Jun 20 11:27:19 AM CEST 2022
+  Boot time: Mon Jun 20 10:33:53 AM CEST 2022
+  Time Zone: Europe/Belgrade
+  Uptime:    53 min,  2 users
+  LoadAvg:   [2 CPU] 0.00 (0%), 0.00 (0%), 0.00 (0%)
+  /proc/stat:
+    procs_running: 1   procs_blocked: 0    processes [Since boot]: 11582
+    cpu [Utilization since boot]:
+      us 0%, ni 0%, sys 0%, idle 99%, iowait 0%, irq 0%, sftirq 0%, steal 0%
+
+CPU
+  2 logical processors 
+  2 Intel Pentium CPU G4560 @ 3.50GHz (flags: aes,constant_tsc,lm,nx,pae,rdrand) 
+
+MEMORY
+  Stats graphed as percent of MemTotal:
+    MemUsed    ▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊▊..................................  32.3%
+    Buffers    ..................................................   0.3%
+    Cached     ▊▊▊▊▊▊▊...........................................  13.8%
+    HugePages  ..................................................   0.0%
+    Dirty      ..................................................   0.0%
+  RAM:
+    1.7 GiB total ram
+    0.6 GiB (32%) used
+    0.3 GiB (18%) used excluding Buffers/Cached
+    0 GiB (0%) dirty
+  HugePages:
+    No ram pre-allocated to HugePages
+  THP:
+    0.01 GiB allocated to THP 
+  LowMem/Slab/PageTables/Shmem:
+    0.08 GiB (5%) of total ram used for Slab
+    0 GiB (0%) of total ram used for PageTables
+    0.01 GiB (0%) of total ram used for Shmem
+  Swap:
+    0 GiB (0%) used of 0.8 GiB total
+
+STORAGE
+  Whole Disks from /proc/partitions:
+    0 disks, totaling 0 GiB (0.00 TiB)
+    - - - - - - - - - - - - - - - - - - - - -
+    Disk 	Size in GiB
+    ----	-----------
+
+  Disk layout from lsblk:
+    NAME               MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
+    sr0                 11:0    1  767M  0 rom  
+    nvme0n1            259:0    0    8G  0 disk 
+    ├─nvme0n1p1        259:1    0  600M  0 part /boot/efi
+    ├─nvme0n1p2        259:2    0    1G  0 part /boot
+    └─nvme0n1p3        259:3    0  6.4G  0 part 
+      ├─rl_rocky9-root 253:0    0  5.6G  0 lvm  /
+      └─rl_rocky9-swap 253:1    0  820M  0 lvm  [SWAP]
+
+  Filesystem usage from df:
+    Filesystem                 1K-blocks    Used Available Use% Mounted on
+    /dev/mapper/rl_rocky9-root   5871616 1025672   4845944  18% /
+    /dev/nvme0n1p2               1038336  194616    843720  19% /boot
+    /dev/nvme0n1p1                613184    7136    606048   2% /boot/efi
+
+DM-MULTIPATH
+  [No paths detected]
+
+LSPCI
+  Net:
+    (1) VMware VMXNET3 Ethernet Controller (rev 01)
+  Storage:
+    (1) VMware SATA AHCI controller
+  VGA:
+    VMware SVGA II Adapter
+
+ETHTOOL
+  Interface Status:
+    ens160  0000:03:00.0  link=up 10000Mb/s full (autoneg=N)  rx ring 1024/4096  drv vmxnet3 v1.6.0.0-k-NAPI / fw UNKNOWN
+  Interface Errors:
+    [None]
+


### PR DESCRIPTION
- VirtualBox 6.1 (Windows 7 64-bit), UEFI without Secure Boot;
- Workstation 15.5 Player (Windows 7 64-bit), UEFI with Secure Boot;
- Hyper-V 10 (Windows 10 64-bit), UEFI with Secure Boot.